### PR TITLE
Keep lesson ids of all selections

### DIFF
--- a/src/app/my-absences/components/my-absences-confirm/my-absences-confirm.component.ts
+++ b/src/app/my-absences/components/my-absences-confirm/my-absences-confirm.component.ts
@@ -12,6 +12,7 @@ import { SETTINGS, Settings } from 'src/app/settings';
 import { MyAbsencesService } from '../../services/my-absences.service';
 import { StorageService } from 'src/app/shared/services/storage.service';
 import { ConfirmAbsencesSelectionService } from 'src/app/shared/services/confirm-absences-selection.service';
+import { uniq, flatten } from 'lodash-es';
 
 @Component({
   selector: 'erz-my-absences-confirm',
@@ -21,7 +22,7 @@ import { ConfirmAbsencesSelectionService } from 'src/app/shared/services/confirm
 })
 export class MyAbsencesConfirmComponent extends MyAbsencesAbstractConfirmComponent {
   selectedLessonIds$ = this.selectionService.selectedIds$.pipe(
-    map((selectedIds) => selectedIds[0]?.lessonIds || [])
+    map((selectedIds) => uniq(flatten(selectedIds.map((s) => s.lessonIds))))
   );
   protected confirmationStateId = this.settings.unconfirmedAbsencesRefreshTime;
 

--- a/src/app/my-absences/components/my-absences-confirm/my-absences-report-confirm.component.ts
+++ b/src/app/my-absences/components/my-absences-confirm/my-absences-report-confirm.component.ts
@@ -14,6 +14,7 @@ import { StorageService } from 'src/app/shared/services/storage.service';
 import { MyAbsencesReportStateService } from '../../services/my-absences-report-state.service';
 import { MyAbsencesReportSelectionService } from '../../services/my-absences-report-selection.service';
 import { PresenceType } from 'src/app/shared/models/presence-type.model';
+import { flatten, uniq } from 'lodash-es';
 
 @Component({
   selector: 'erz-my-absences-confirm',
@@ -23,7 +24,7 @@ import { PresenceType } from 'src/app/shared/models/presence-type.model';
 })
 export class MyAbsencesReportConfirmComponent extends MyAbsencesAbstractConfirmComponent {
   selectedLessonIds$ = this.selectionService.selectedIds$.pipe(
-    map((selectedIds) => selectedIds[0]?.lessonIds || [])
+    map((selectedIds) => uniq(flatten(selectedIds.map((s) => s.lessonIds))))
   );
   protected confirmationStateId = this.settings.checkableAbsenceStateId;
 

--- a/src/app/my-absences/components/my-absences-show/my-absences-show.component.ts
+++ b/src/app/my-absences/components/my-absences-show/my-absences-show.component.ts
@@ -12,6 +12,7 @@ import { ConfirmAbsencesSelectionService } from 'src/app/shared/services/confirm
 import { ReportsService } from 'src/app/shared/services/reports.service';
 import { not } from 'src/app/shared/utils/filter';
 import { isEmptyArray } from 'src/app/shared/utils/array';
+import { flatten, uniq } from 'lodash-es';
 
 @Component({
   selector: 'erz-my-absences-show',
@@ -54,7 +55,9 @@ export class MyAbsencesShowComponent implements OnInit, OnDestroy {
     ]).pipe(
       switchMap(([selectedWithout, selectedIds]) =>
         selectedWithout.length === 0 && selectedIds.length > 0
-          ? this.getReportRecordIds(selectedIds[0].lessonIds)
+          ? this.getReportRecordIds(
+              uniq(flatten(selectedIds.map((s) => s.lessonIds)))
+            )
           : of(null)
       ),
       map((recordIds) =>


### PR DESCRIPTION
Nicht nur die erste Selection verwenden um die LessonIds zu ermitteln, sondern alle.

Würdest du das noch in eine Hilfsmethode oder so auslagern?