### PR TITLE
Preselect absence type and don't override existing absence types on edit #211

### DIFF
--- a/src/app/edit-absences/components/edit-absences-edit/edit-absences-edit.component.html
+++ b/src/app/edit-absences/components/edit-absences-edit/edit-absences-edit.component.html
@@ -2,12 +2,13 @@
   class="erz-container erz-container-limited erz-container-padding-y"
   *erzLet="{
     confirmationStates: confirmationStates$ | async,
-    categories: activeCategories$ | async
+    categories: activeCategories$ | async,
+    formGroup: formGroup$ | async
   } as data"
 >
   <form
-    *ngIf="data.confirmationStates"
-    [formGroup]="formGroup"
+    *ngIf="data.formGroup && data.confirmationStates"
+    [formGroup]="data.formGroup"
     (ngSubmit)="onSubmit()"
   >
     <div class="alert alert-danger" *ngFor="let error of formErrors$ | async">

--- a/src/app/edit-absences/components/edit-absences-edit/edit-absences-edit.component.spec.ts
+++ b/src/app/edit-absences/components/edit-absences-edit/edit-absences-edit.component.spec.ts
@@ -1,15 +1,55 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { HttpTestingController } from '@angular/common/http/testing';
+import { of, Observable } from 'rxjs';
+import { isEqual } from 'lodash-es';
 
-import { buildTestModuleMetadata } from 'src/spec-helpers';
+import { buildTestModuleMetadata, settings } from 'src/spec-helpers';
 import { EditAbsencesEditComponent } from './edit-absences-edit.component';
 import { EditAbsencesStateService } from '../../services/edit-absences-state.service';
+import { PresenceTypesService } from 'src/app/shared/services/presence-types.service';
+import { buildPresenceType, buildLessonPresence } from 'src/spec-builders';
+import { DropDownItemsRestService } from 'src/app/shared/services/drop-down-items-rest.service';
+import { PresenceType } from 'src/app/shared/models/presence-type.model';
+import { DropDownItem } from 'src/app/shared/models/drop-down-item.model';
 
 describe('EditAbsencesEditComponent', () => {
   let component: EditAbsencesEditComponent;
   let fixture: ComponentFixture<EditAbsencesEditComponent>;
+  let element: HTMLElement;
+  let httpTestingController: HttpTestingController;
+  let state: EditAbsencesStateService;
+  let absence: PresenceType;
+  let doctor: PresenceType;
+  let ill: PresenceType;
+  let late: PresenceType;
+  let dispensation: PresenceType;
+  let halfDay: PresenceType;
 
   beforeEach(async(() => {
+    absence = buildPresenceType(settings.absencePresenceTypeId, true, false);
+    absence.NeedsConfirmation = true;
+
+    doctor = buildPresenceType(13, true, false);
+    doctor.NeedsConfirmation = true;
+    doctor.Designation = 'Arzt';
+
+    ill = buildPresenceType(14, true, false);
+    ill.NeedsConfirmation = true;
+    ill.Designation = 'Krank';
+
+    late = buildPresenceType(settings.latePresenceTypeId, false, true);
+    late.Designation = 'Verspätung';
+
+    dispensation = buildPresenceType(
+      settings.dispensationPresenceTypeId,
+      false,
+      false
+    );
+    dispensation.IsDispensation = true;
+
+    halfDay = buildPresenceType(settings.halfDayPresenceTypeId, false, false);
+    halfDay.IsHalfDay = true;
+
     TestBed.configureTestingModule(
       buildTestModuleMetadata({
         declarations: [EditAbsencesEditComponent],
@@ -18,22 +58,357 @@ describe('EditAbsencesEditComponent', () => {
             provide: EditAbsencesStateService,
             useValue: {
               presenceTypes$: of([]),
-              selected: [{ lessonIds: [1, 2, 3], personIds: [4, 5, 6] }],
+              selected: [],
               resetSelection: jasmine.createSpy('resetSelection'),
+            },
+          },
+          {
+            provide: PresenceTypesService,
+            useValue: {
+              presenceTypes$: of([
+                absence,
+                doctor,
+                ill,
+                late,
+                dispensation,
+                halfDay,
+              ]),
+              confirmationTypes$: of([absence, doctor, ill]),
+              incidentTypes$: of([late]),
+              halfDayActive$: of(true),
+            },
+          },
+          {
+            provide: DropDownItemsRestService,
+            useValue: {
+              getAbsenceConfirmationStates(): Observable<
+                ReadonlyArray<DropDownItem>
+              > {
+                return of([
+                  {
+                    Key: settings.excusedAbsenceStateId,
+                    Value: 'entschuldigt',
+                  },
+                  {
+                    Key: settings.unexcusedAbsenceStateId,
+                    Value: 'unentschuldigt',
+                  },
+                  {
+                    Key: settings.unconfirmedAbsenceStateId,
+                    Value: 'zu bestätigen',
+                  },
+                  {
+                    Key: settings.checkableAbsenceStateId,
+                    Value: 'zu kontrollieren',
+                  },
+                ]);
+              },
             },
           },
         ],
       })
     ).compileComponents();
+
+    httpTestingController = TestBed.inject(HttpTestingController);
+    state = TestBed.inject(EditAbsencesStateService);
   }));
 
   beforeEach(() => {
     fixture = TestBed.createComponent(EditAbsencesEditComponent);
     component = fixture.componentInstance;
-    fixture.detectChanges();
+    element = fixture.debugElement.nativeElement;
+
+    // Don't do any navigation
+    (component as any).onSaveSuccess = jasmine.createSpy('onSaveSuccess');
   });
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+  afterEach(() => {
+    httpTestingController.verify();
   });
+
+  describe('initial absence type', () => {
+    it('preselects the absence type if all selected entries have the same', () => {
+      state.selected = [
+        buildLessonPresence(
+          1,
+          new Date(),
+          new Date(),
+          'Math',
+          undefined,
+          ill.Id
+        ),
+        buildLessonPresence(
+          2,
+          new Date(),
+          new Date(),
+          'Deutsch',
+          undefined,
+          ill.Id
+        ),
+      ];
+      fixture.detectChanges();
+      expect(getSelect('absenceTypeId').value).toContain(String(ill.Id));
+    });
+
+    it('is empty if absence type of selected entries differs', () => {
+      state.selected = [
+        buildLessonPresence(
+          1,
+          new Date(),
+          new Date(),
+          'Math',
+          undefined,
+          doctor.Id
+        ),
+        buildLessonPresence(
+          2,
+          new Date(),
+          new Date(),
+          'Deutsch',
+          undefined,
+          ill.Id
+        ),
+      ];
+      fixture.detectChanges();
+
+      expect(getSelect('absenceTypeId').value).toContain('null');
+    });
+  });
+
+  describe('form submission', () => {
+    beforeEach(() => {
+      state.selected = [
+        buildLessonPresence(
+          1,
+          new Date(),
+          new Date(),
+          'Math',
+          undefined,
+          undefined,
+          undefined,
+          100
+        ),
+        buildLessonPresence(
+          2,
+          new Date(),
+          new Date(),
+          'Französisch',
+          undefined,
+          absence.Id,
+          undefined,
+          100
+        ),
+        buildLessonPresence(
+          3,
+          new Date(),
+          new Date(),
+          'Math',
+          undefined,
+          doctor.Id,
+          undefined,
+          100
+        ),
+        buildLessonPresence(
+          4,
+          new Date(),
+          new Date(),
+          'Englisch',
+          undefined,
+          ill.Id,
+          undefined,
+          100
+        ),
+        buildLessonPresence(
+          5,
+          new Date(),
+          new Date(),
+          'Chemie',
+          undefined,
+          late.Id,
+          undefined,
+          100
+        ),
+        buildLessonPresence(
+          6,
+          new Date(),
+          new Date(),
+          'Zeichnen',
+          undefined,
+          dispensation.Id,
+          undefined,
+          100
+        ),
+        buildLessonPresence(
+          7,
+          new Date(),
+          new Date(),
+          'Turnen',
+          undefined,
+          halfDay.Id,
+          undefined,
+          100
+        ),
+      ];
+      fixture.detectChanges();
+    });
+
+    it('resets all entries if updating to present', () => {
+      clickRadio('present');
+      clickSave();
+
+      expectResetRequest({
+        LessonIds: [1, 2, 3, 4, 5, 6, 7],
+        PersonIds: [100],
+      });
+    });
+
+    it('updates all entries to chosen absence type if excused', () => {
+      clickRadio('entschuldigt');
+      selectOption('absenceTypeId', 'Krank');
+      clickSave();
+
+      expectEditRequest({
+        LessonIds: [1, 2, 3, 4, 5, 6, 7],
+        PersonIds: [100],
+        PresenceTypeId: ill.Id,
+        ConfirmationValue: settings.excusedAbsenceStateId,
+      });
+    });
+
+    it('updates all entries to default absence type if unexcused', () => {
+      clickRadio('unentschuldigt');
+      clickSave();
+
+      expectEditRequest({
+        LessonIds: [1, 2, 3, 4, 5, 6, 7],
+        PersonIds: [100],
+        PresenceTypeId: settings.absencePresenceTypeId,
+        ConfirmationValue: settings.unexcusedAbsenceStateId,
+      });
+    });
+
+    it('marks all entries as unconfirmed but preserves absence type if available', () => {
+      clickRadio('zu bestätigen');
+      clickSave();
+
+      expectEditRequest({
+        LessonIds: [1, 5, 6, 7],
+        PersonIds: [100],
+        PresenceTypeId: absence.Id,
+        ConfirmationValue: settings.unconfirmedAbsenceStateId,
+      });
+      expectEditRequest({
+        LessonIds: [2, 3, 4],
+        PersonIds: [100],
+        ConfirmationValue: settings.unconfirmedAbsenceStateId,
+      });
+    });
+
+    it('marks all entries as checkable but preserves absence type if available', () => {
+      clickRadio('zu kontrollieren');
+      clickSave();
+
+      expectEditRequest({
+        LessonIds: [1, 5, 6, 7],
+        PersonIds: [100],
+        PresenceTypeId: absence.Id,
+        ConfirmationValue: settings.checkableAbsenceStateId,
+      });
+      expectEditRequest({
+        LessonIds: [2, 3, 4],
+        PersonIds: [100],
+        ConfirmationValue: settings.checkableAbsenceStateId,
+      });
+    });
+
+    it('updates entries to dispensation', () => {
+      clickRadio('dispensation');
+      clickSave();
+
+      expectEditRequest({
+        LessonIds: [1, 2, 3, 4, 5, 6, 7],
+        PersonIds: [100],
+        PresenceTypeId: settings.dispensationPresenceTypeId,
+      });
+    });
+
+    it('updates entries to half day', () => {
+      clickRadio('half-day');
+      clickSave();
+
+      expectEditRequest({
+        LessonIds: [1, 2, 3, 4, 5, 6, 7],
+        PersonIds: [100],
+        PresenceTypeId: settings.halfDayPresenceTypeId,
+      });
+    });
+
+    it('updates entries to incident', () => {
+      clickRadio('incident');
+      selectOption('incidentId', 'Verspätung');
+      clickSave();
+
+      expectEditRequest({
+        LessonIds: [1, 2, 3, 4, 5, 6, 7],
+        PersonIds: [100],
+        PresenceTypeId: settings.latePresenceTypeId,
+      });
+    });
+  });
+
+  function getSelect(controlName: string): HTMLSelectElement {
+    const select = element.querySelector(
+      `select[formControlName="${controlName}"]`
+    ) as HTMLSelectElement | undefined;
+    expect(select).toBeDefined();
+    return select as HTMLSelectElement;
+  }
+
+  function selectOption(controlName: string, optionLabel: string): void {
+    const select = getSelect(controlName);
+    const option = Array.prototype.slice
+      .call(select.options)
+      .find((o) => o.label === optionLabel);
+    select.value = option?.value;
+    select.dispatchEvent(new Event('change'));
+  }
+
+  function clickRadio(labelText: string): void {
+    const labels = Array.prototype.slice.call(
+      element.querySelectorAll('label')
+    );
+    const label = labels.find((l) => l.textContent.includes(labelText)) as
+      | HTMLElement
+      | undefined;
+    return label?.parentElement?.querySelector('input')?.click();
+  }
+
+  function clickSave(): void {
+    const button = element.querySelector('button[type="submit"]') as
+      | HTMLButtonElement
+      | undefined;
+    button?.click();
+  }
+
+  function expectResetRequest(body: any): void {
+    const url = 'https://eventotest.api/LessonPresences/Reset';
+
+    httpTestingController
+      .expectOne(
+        (req) => req.urlWithParams === url && isEqual(req.body, body),
+        url
+      )
+      .flush('');
+  }
+
+  function expectEditRequest(body: any): void {
+    const url = 'https://eventotest.api/LessonPresences/Edit';
+
+    httpTestingController
+      .expectOne(
+        (req) => req.urlWithParams === url && isEqual(req.body, body),
+        url
+      )
+      .flush('');
+  }
 });

--- a/src/app/edit-absences/components/edit-absences-list/edit-absences-list.component.ts
+++ b/src/app/edit-absences/components/edit-absences-list/edit-absences-list.component.ts
@@ -51,9 +51,9 @@ export class EditAbsencesListComponent
       .subscribe(() => this.selectionService.clear());
 
     // Remember selected entries
-    this.selectionService.selectedIds$
+    this.selectionService.selection$
       .pipe(takeUntil(this.destroy$))
-      .subscribe((ids) => (this.state.selected = ids));
+      .subscribe((selected) => (this.state.selected = selected));
 
     // Reload entries for current filter when ?reload=true
     this.route.queryParams

--- a/src/app/edit-absences/services/edit-absences-selection.service.ts
+++ b/src/app/edit-absences/services/edit-absences-selection.service.ts
@@ -1,13 +1,9 @@
 import { Injectable } from '@angular/core';
-import { map } from 'rxjs/operators';
 
 import { SelectionService } from 'src/app/shared/services/selection.service';
 import { LessonPresence } from 'src/app/shared/models/lesson-presence.model';
-import { getIdsGroupedByPerson } from 'src/app/shared/utils/lesson-presences';
 
 @Injectable()
 export class EditAbsencesSelectionService extends SelectionService<
   LessonPresence
-> {
-  selectedIds$ = this.selection$.pipe(map(getIdsGroupedByPerson));
-}
+> {}

--- a/src/app/edit-absences/services/edit-absences-state.service.ts
+++ b/src/app/edit-absences/services/edit-absences-state.service.ts
@@ -52,10 +52,7 @@ export class EditAbsencesStateService
     this.absenceConfirmationStates$,
   ]).pipe(map(spread(buildPresenceControlEntries)), shareReplay(1));
 
-  selected: ReadonlyArray<{
-    lessonIds: ReadonlyArray<number>;
-    personIds: ReadonlyArray<number>;
-  }> = [];
+  selected: ReadonlyArray<LessonPresence> = [];
 
   constructor(
     location: Location,

--- a/src/app/edit-absences/services/edit-absences-update.service.spec.ts
+++ b/src/app/edit-absences/services/edit-absences-update.service.spec.ts
@@ -1,0 +1,17 @@
+import { TestBed } from '@angular/core/testing';
+
+import { EditAbsencesUpdateService } from './edit-absences-update.service';
+import { buildTestModuleMetadata } from 'src/spec-helpers';
+
+describe('EditAbsencesUpdateService', () => {
+  let service: EditAbsencesUpdateService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule(buildTestModuleMetadata({}));
+    service = TestBed.inject(EditAbsencesUpdateService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/edit-absences/services/edit-absences-update.service.ts
+++ b/src/app/edit-absences/services/edit-absences-update.service.ts
@@ -1,0 +1,151 @@
+import { Injectable, Inject } from '@angular/core';
+import { Observable, combineLatest } from 'rxjs';
+import { mapTo } from 'rxjs/operators';
+
+import { LessonPresencesUpdateRestService } from 'src/app/shared/services/lesson-presences-update-rest.service';
+import { LessonPresence } from 'src/app/shared/models/lesson-presence.model';
+import { getIdsGroupedByPerson } from 'src/app/shared/utils/lesson-presences';
+import { SETTINGS, Settings } from 'src/app/settings';
+import { PresenceType } from 'src/app/shared/models/presence-type.model';
+import { not } from 'src/app/shared/utils/filter';
+
+export enum Category {
+  Absent = 'absent',
+  Dispensation = 'dispensation',
+  HalfDay = 'half-day',
+  Incident = 'incident',
+  Present = 'present',
+}
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EditAbsencesUpdateService {
+  constructor(
+    private updateService: LessonPresencesUpdateRestService,
+    @Inject(SETTINGS) private settings: Settings
+  ) {}
+
+  update(
+    entries: ReadonlyArray<LessonPresence>,
+    presenceTypes: ReadonlyArray<PresenceType>,
+    category: Category,
+    confirmationValue: Option<number>,
+    absenceTypeId: Option<number>,
+    incidentId: Option<number>
+  ): Observable<void> {
+    let requests: ReadonlyArray<Observable<void>> = [];
+    switch (category) {
+      case Category.Present:
+        requests = this.createResetBulkRequests(entries);
+        break;
+      case Category.Absent:
+        requests = this.createAbsentEditBulkRequests(
+          entries,
+          presenceTypes,
+          confirmationValue,
+          absenceTypeId
+        );
+        break;
+      case Category.Dispensation:
+        requests = this.createEditBulkRequests(
+          entries,
+          null,
+          this.settings.dispensationPresenceTypeId
+        );
+        break;
+      case Category.HalfDay:
+        requests = this.createEditBulkRequests(
+          entries,
+          null,
+          this.settings.halfDayPresenceTypeId
+        );
+        break;
+      case Category.Incident:
+        requests = this.createEditBulkRequests(entries, null, incidentId);
+        break;
+    }
+
+    return combineLatest(requests).pipe(mapTo(undefined));
+  }
+
+  private createAbsentEditBulkRequests(
+    entries: ReadonlyArray<LessonPresence>,
+    presenceTypes: ReadonlyArray<PresenceType>,
+    confirmationValue: Option<number>,
+    absenceTypeId: Option<number>
+  ): ReadonlyArray<Observable<void>> {
+    if (confirmationValue === this.settings.excusedAbsenceStateId) {
+      // Update all entries to the absence type selected by the user
+      return this.createEditBulkRequests(
+        entries,
+        confirmationValue,
+        absenceTypeId
+      );
+    } else if (confirmationValue === this.settings.unexcusedAbsenceStateId) {
+      // Update all entries to the default absence type (possibly
+      // overriding the existing absence type)
+      return this.createEditBulkRequests(
+        entries,
+        confirmationValue,
+        this.settings.absencePresenceTypeId
+      );
+    } else {
+      return [
+        // Update presences, dispensations, half days an incidents
+        // to the default absence type
+        ...this.createEditBulkRequests(
+          entries.filter(overrideAbsenceType(presenceTypes, this.settings)),
+          confirmationValue,
+          this.settings.absencePresenceTypeId
+        ),
+        // Keep the existing absence type for all other entries
+        ...this.createEditBulkRequests(
+          entries.filter(
+            not(overrideAbsenceType(presenceTypes, this.settings))
+          ),
+          confirmationValue,
+          null
+        ),
+      ];
+    }
+  }
+
+  private createResetBulkRequests(
+    entries: ReadonlyArray<LessonPresence>
+  ): ReadonlyArray<Observable<void>> {
+    return getIdsGroupedByPerson(entries).map(({ lessonIds, personIds }) =>
+      this.updateService.removeLessonPresences(lessonIds, personIds)
+    );
+  }
+
+  private createEditBulkRequests(
+    entries: ReadonlyArray<LessonPresence>,
+    confirmationValue: Option<number>,
+    absenceTypeId: Option<number>
+  ): ReadonlyArray<Observable<void>> {
+    return getIdsGroupedByPerson(entries).map(({ lessonIds, personIds }) =>
+      this.updateService.editLessonPresences(
+        lessonIds,
+        personIds,
+        absenceTypeId || undefined,
+        confirmationValue || undefined
+      )
+    );
+  }
+}
+
+function overrideAbsenceType(
+  presenceTypes: ReadonlyArray<PresenceType>,
+  settings: Settings
+): (entry: LessonPresence) => boolean {
+  return (entry) => {
+    const presenceType = presenceTypes.find((t) => t.Id === entry.TypeRef.Id);
+    return (
+      !presenceType ||
+      presenceType.Id === settings.dispensationPresenceTypeId ||
+      presenceType.Id === settings.halfDayPresenceTypeId ||
+      presenceType.IsIncident
+    );
+  };
+}

--- a/src/app/my-absences/components/my-absences-confirm/my-absences-abstract-confirm.component.ts
+++ b/src/app/my-absences/components/my-absences-confirm/my-absences-abstract-confirm.component.ts
@@ -4,15 +4,7 @@ import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { TranslateService } from '@ngx-translate/core';
 import { BehaviorSubject, combineLatest, Observable, Subject, of } from 'rxjs';
-import {
-  finalize,
-  map,
-  filter,
-  startWith,
-  switchMap,
-  take,
-  pluck,
-} from 'rxjs/operators';
+import { finalize, map, filter, switchMap, take, pluck } from 'rxjs/operators';
 
 import { LessonPresencesUpdateRestService } from 'src/app/shared/services/lesson-presences-update-rest.service';
 import { PresenceTypesService } from 'src/app/shared/services/presence-types.service';
@@ -41,13 +33,10 @@ export abstract class MyAbsencesAbstractConfirmComponent
     )
   );
 
-  absenceTypeIdErrors$ = combineLatest([
-    getValidationErrors(this.formGroup.get('absenceTypeId')),
+  absenceTypeIdErrors$ = getValidationErrors(
+    of(this.formGroup),
     this.submitted$,
-  ]).pipe(
-    filter((v) => v[1]),
-    map((v) => v[0]),
-    startWith([])
+    'absenceTypeId'
   );
 
   abstract selectedLessonIds$: Observable<ReadonlyArray<number>>;

--- a/src/app/my-profile/components/my-profile-edit/my-profile-edit.component.ts
+++ b/src/app/my-profile/components/my-profile-edit/my-profile-edit.component.ts
@@ -3,7 +3,7 @@ import { FormBuilder, FormGroup, Validators } from '@angular/forms';
 import { Router } from '@angular/router';
 import { ToastrService } from 'ngx-toastr';
 import { TranslateService } from '@ngx-translate/core';
-import { BehaviorSubject, combineLatest } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 import {
   pluck,
   map,
@@ -11,14 +11,12 @@ import {
   switchMap,
   finalize,
   shareReplay,
-  filter,
-  startWith,
 } from 'rxjs/operators';
 
 import { Person } from 'src/app/shared/models/person.model';
 import { MyProfileService } from '../../services/my-profile.service';
 import { PersonsRestService } from 'src/app/shared/services/persons-rest.service';
-import { getControlValidationErrors } from 'src/app/shared/utils/form';
+import { getValidationErrors } from 'src/app/shared/utils/form';
 
 @Component({
   selector: 'erz-my-profile-edit',
@@ -36,14 +34,10 @@ export class MyProfileEditComponent implements OnInit {
   saving$ = new BehaviorSubject(false);
   private submitted$ = new BehaviorSubject(false);
 
-  email2Errors$ = combineLatest([
-    this.formGroup$.pipe(switchMap(getControlValidationErrors('email2'))),
+  email2Errors$ = getValidationErrors(
+    this.formGroup$,
     this.submitted$,
-  ]).pipe(
-    filter((v) => v[1]),
-    map((v) => v[0]),
-    startWith([]),
-    shareReplay(1)
+    'email2'
   );
 
   constructor(

--- a/src/app/shared/components/confirm-absences/confirm-absences.component.ts
+++ b/src/app/shared/components/confirm-absences/confirm-absences.component.ts
@@ -26,7 +26,6 @@ import { TranslateService } from '@ngx-translate/core';
 import { notNull } from 'src/app/shared/utils/filter';
 import {
   getValidationErrors,
-  getControlValidationErrors,
   getControl,
   getControlValueChanges,
 } from 'src/app/shared/utils/form';
@@ -57,24 +56,11 @@ export class ConfirmAbsencesComponent implements OnInit, OnDestroy {
   saving$ = new BehaviorSubject(false);
   private submitted$ = new BehaviorSubject(false);
 
-  formErrors$ = combineLatest([
-    this.formGroup$.pipe(switchMap(getValidationErrors)),
+  formErrors$ = getValidationErrors(this.formGroup$, this.submitted$);
+  absenceTypeIdErrors$ = getValidationErrors(
+    this.formGroup$,
     this.submitted$,
-  ]).pipe(
-    filter((v) => v[1]),
-    map((v) => v[0]),
-    startWith([])
-  );
-
-  absenceTypeIdErrors$ = combineLatest([
-    this.formGroup$.pipe(
-      switchMap(getControlValidationErrors('absenceTypeId'))
-    ),
-    this.submitted$,
-  ]).pipe(
-    filter((v) => v[1]),
-    map((v) => v[0]),
-    startWith([])
+    'absenceTypeId'
   );
 
   private confirmationStates$ = this.dropDownItemsService

--- a/src/app/shared/utils/form.spec.ts
+++ b/src/app/shared/utils/form.spec.ts
@@ -1,0 +1,148 @@
+import { FormGroup, FormControl, Validators } from '@angular/forms';
+import { Subject } from 'rxjs';
+
+import {
+  getControl,
+  getControlValueChanges,
+  getValidationErrors,
+} from './form';
+
+describe('form utils', () => {
+  let formGroup$: Subject<FormGroup>;
+  let submitted$: Subject<boolean>;
+  let callback: jasmine.Spy;
+
+  beforeEach(() => {
+    formGroup$ = new Subject();
+    submitted$ = new Subject();
+    callback = jasmine.createSpy('callback');
+  });
+
+  describe('getValidationErrors', () => {
+    it('returns an observable that emits errors on the form itself', () => {
+      getValidationErrors(formGroup$, submitted$).subscribe(callback);
+      expect(callback).toHaveBeenCalledWith([]);
+
+      callback.calls.reset();
+      const formGroup = buildFormGroup();
+      formGroup$.next(formGroup);
+      expect(callback).not.toHaveBeenCalled();
+
+      callback.calls.reset();
+      formGroup.setErrors({ required: true });
+      expect(callback).not.toHaveBeenCalled();
+
+      callback.calls.reset();
+      submitted$.next(true);
+      expect(callback).toHaveBeenCalledWith([
+        { error: 'required', params: null },
+      ]);
+
+      callback.calls.reset();
+      formGroup.setErrors(null);
+      expect(callback).toHaveBeenCalledWith([]);
+
+      callback.calls.reset();
+      const anotherFormGroup = buildFormGroup();
+      formGroup$.next(anotherFormGroup);
+      anotherFormGroup.setErrors({ min: { min: 3, actual: 2 } });
+      expect(callback).toHaveBeenCalledWith([
+        { error: 'min', params: { min: 3, actual: 2 } },
+      ]);
+    });
+
+    it('returns an observable that emits errors on the form control with the given name', () => {
+      getValidationErrors(formGroup$, submitted$, 'foo').subscribe(callback);
+      expect(callback).toHaveBeenCalledWith([]);
+
+      callback.calls.reset();
+      const formGroup = buildFormGroup();
+      formGroup$.next(formGroup);
+      expect(callback).not.toHaveBeenCalled();
+
+      callback.calls.reset();
+      formGroup.get('foo')?.setValue('');
+      expect(callback).not.toHaveBeenCalled();
+
+      callback.calls.reset();
+      submitted$.next(true);
+      expect(callback).toHaveBeenCalledWith([
+        { error: 'required', params: null },
+      ]);
+
+      callback.calls.reset();
+      formGroup.get('foo')?.setValue('456');
+      expect(callback).toHaveBeenCalledWith([]);
+
+      callback.calls.reset();
+      formGroup.get('bar')?.setErrors({ required: true });
+      expect(callback).not.toHaveBeenCalled();
+
+      callback.calls.reset();
+      const anotherFormGroup = buildFormGroup();
+      formGroup$.next(anotherFormGroup);
+      anotherFormGroup.get('foo')?.setValue('');
+      expect(callback).toHaveBeenCalledWith([
+        { error: 'required', params: null },
+      ]);
+    });
+  });
+
+  describe('getControl', () => {
+    it('returns an observable that emits the form control with given name', () => {
+      getControl(formGroup$, 'foo').subscribe(callback);
+      expect(callback).not.toHaveBeenCalled();
+
+      const formGroup = buildFormGroup();
+      formGroup$.next(formGroup);
+      expect(callback).toHaveBeenCalledWith(formGroup.get('foo'));
+
+      callback.calls.reset();
+      const anotherFormGroup = buildFormGroup();
+      formGroup$.next(anotherFormGroup);
+      expect(callback).not.toHaveBeenCalledWith(formGroup.get('foo'));
+      expect(callback).toHaveBeenCalledWith(anotherFormGroup.get('foo'));
+    });
+
+    it('returns an observable that emits nothing if no control with given name exists', () => {
+      getControl(formGroup$, 'baz').subscribe(callback);
+      expect(callback).not.toHaveBeenCalled();
+
+      const formGroup = buildFormGroup();
+      formGroup$.next(formGroup);
+      expect(callback).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('getControlValueChanges', () => {
+    it("returns an observable that emits a form control's values", () => {
+      getControlValueChanges(formGroup$, 'foo').subscribe(callback);
+      expect(callback).not.toHaveBeenCalled();
+
+      const formGroup = buildFormGroup();
+      formGroup$.next(formGroup);
+      expect(callback).not.toHaveBeenCalled();
+
+      formGroup.get('foo')?.setValue('456');
+      expect(callback).toHaveBeenCalledWith('456');
+
+      callback.calls.reset();
+      const anotherFormGroup = buildFormGroup();
+      formGroup$.next(anotherFormGroup);
+      expect(callback).not.toHaveBeenCalled();
+
+      formGroup.get('foo')?.setValue('789');
+      expect(callback).not.toHaveBeenCalled();
+
+      anotherFormGroup.get('foo')?.setValue('999');
+      expect(callback).toHaveBeenCalledWith('999');
+    });
+  });
+});
+
+function buildFormGroup(): FormGroup {
+  return new FormGroup({
+    foo: new FormControl('123', Validators.required),
+    bar: new FormControl(),
+  });
+}


### PR DESCRIPTION
Umgesetzt ist jetzt die Variante mit effektiv zwei Requests, wenn es nötig wird. Ich habe für die Edit Komponente für diese verschiedenen Möglichkeiten einen Test geschrieben.